### PR TITLE
Registry backed dictionary - NullReferenceException fix

### DIFF
--- a/BeamgunApp/Models/RegistryBackedDictionary.cs
+++ b/BeamgunApp/Models/RegistryBackedDictionary.cs
@@ -33,24 +33,21 @@ namespace BeamgunApp.Models
 
         public double GetWithDefault(string key, double defaultValue)
         {
-            double result;
-            return double.TryParse(Registry.GetValue(BeamgunBaseKey, key, defaultValue).ToString(), out result)
+            return double.TryParse(Registry.GetValue(BeamgunBaseKey, key, defaultValue)?.ToString(), out var result)
                 ? result
                 : defaultValue;
         }
         
         public uint GetWithDefault(string key, uint defaultValue)
         {
-            uint result;
-            return uint.TryParse(Registry.GetValue(BeamgunBaseKey, key, defaultValue).ToString(), out result)
+            return uint.TryParse(Registry.GetValue(BeamgunBaseKey, key, defaultValue)?.ToString(), out var result)
                 ? result
                 : defaultValue;
         }
 
         public Guid GetWithDefault(string key, Guid defaultValue)
         {
-            Guid result;
-            return Guid.TryParse(Registry.GetValue(BeamgunBaseKey, key, defaultValue).ToString(), out result)
+            return Guid.TryParse(Registry.GetValue(BeamgunBaseKey, key, defaultValue)?.ToString(), out var result)
                 ? result
                 : defaultValue;
         }

--- a/BeamgunApp/Models/RegistryBackedDictionary.cs
+++ b/BeamgunApp/Models/RegistryBackedDictionary.cs
@@ -16,50 +16,47 @@ namespace BeamgunApp.Models
     public class RegistryBackedDictionary : IDynamicDictionary
     {
         public Action<string> BadCastReport;
-        public const string BeamgunBaseKey = "HKEY_CURRENT_USER\\SOFTWARE\\Beamgun";
+        public const string BeamgunBaseKey = @"HKEY_CURRENT_USER\SOFTWARE\Beamgun";
 
         public string GetWithDefault(string key, string defaultValue)
         {
-            try
-            {
-                return (string)Registry.GetValue(BeamgunBaseKey, key, defaultValue);
-            }
-            catch (InvalidCastException)
-            {
-                BadCastReport($"Could not parse {BeamgunBaseKey} {key}. Using default {defaultValue}.");
-                return defaultValue;
-            }
+            return GetRegistryValue(key, defaultValue) ?? defaultValue;
         }
 
         public double GetWithDefault(string key, double defaultValue)
         {
-            return double.TryParse(Registry.GetValue(BeamgunBaseKey, key, defaultValue)?.ToString(), out var result)
+            return double.TryParse(GetRegistryValue(key, defaultValue), out var result)
                 ? result
                 : defaultValue;
         }
         
         public uint GetWithDefault(string key, uint defaultValue)
         {
-            return uint.TryParse(Registry.GetValue(BeamgunBaseKey, key, defaultValue)?.ToString(), out var result)
+            return uint.TryParse(GetRegistryValue(key, defaultValue), out var result)
                 ? result
                 : defaultValue;
         }
 
         public Guid GetWithDefault(string key, Guid defaultValue)
         {
-            return Guid.TryParse(Registry.GetValue(BeamgunBaseKey, key, defaultValue)?.ToString(), out var result)
+            return Guid.TryParse(GetRegistryValue(key, defaultValue), out var result)
                 ? result
                 : defaultValue;
         }
 
         public bool GetWithDefault(string key, bool defaultValue)
         {
-            return Registry.GetValue(BeamgunBaseKey, key, defaultValue ? "True" : "False").ToString() == "True";
+            return (GetRegistryValue(key, defaultValue) ?? "True") == "True";
         }
 
         public void Set<T>(string key, T value)
         {
             Registry.SetValue(BeamgunBaseKey, key, value);
+        }
+
+        private string GetRegistryValue(string key, object defaultValue)
+        {
+            return Registry.GetValue(BeamgunBaseKey, key, defaultValue)?.ToString();
         }
     }
 }


### PR DESCRIPTION
I encountered NullReferenceException after trying to run the application straight after building, because the registry keys were lacking and `.ToString()` was called on nulls without the `?.` safe navigation operator.

I fixed this, and then did some minor refactoring along the way.